### PR TITLE
refactor: replace pima task with sonar in examples

### DIFF
--- a/R/TuningSpace.R
+++ b/R/TuningSpace.R
@@ -30,7 +30,7 @@
 #' # Tune learner
 #' instance = tune(
 #'   tnr("random_search"),
-#'   task = tsk("pima"),
+#'   task = tsk("sonar"),
 #'   learner = learner,
 #'   resampling = rsmp ("holdout"),
 #'   measure = msr("classif.ce"),

--- a/README.Rmd
+++ b/README.Rmd
@@ -88,10 +88,10 @@ library(mlr3tuningspaces)
 
 learner = lts(lrn("classif.rpart"))
 
-# tune learner on pima data set
+# tune learner on sonar data set
 instance = tune(
   tnr("random_search"),
-  task = tsk("pima"),
+  task = tsk("sonar"),
   learner = learner,
   resampling = rsmp("holdout"),
   measure = msr("classif.ce"),

--- a/README.md
+++ b/README.md
@@ -78,10 +78,10 @@ library(mlr3tuningspaces)
 
 learner = lts(lrn("classif.rpart"))
 
-# tune learner on pima data set
+# tune learner on sonar data set
 instance = tune(
   tnr("random_search"),
-  task = tsk("pima"),
+  task = tsk("sonar"),
   learner = learner,
   resampling = rsmp("holdout"),
   measure = msr("classif.ce"),

--- a/man/TuningSpace.Rd
+++ b/man/TuningSpace.Rd
@@ -38,7 +38,7 @@ learner$param_set$values = tuning_space$values
 # Tune learner
 instance = tune(
   tnr("random_search"),
-  task = tsk("pima"),
+  task = tsk("sonar"),
   learner = learner,
   resampling = rsmp ("holdout"),
   measure = msr("classif.ce"),


### PR DESCRIPTION
The `pima` task is being removed from mlr3 because the `PimaIndiansDiabetes2` data set was removed from the mlbench package. This replaces its usage in the README and `TuningSpace` example with the `sonar` task.

🤖 Generated with [Claude Code](https://claude.com/claude-code)